### PR TITLE
Feat: create active record association between tasks and categories

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,2 +1,3 @@
 class Category < ApplicationRecord
+  has_many :tasks
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,2 +1,3 @@
 class Task < ApplicationRecord
+  belongs_to :category
 end

--- a/db/migrate/20240705173503_create_tasks.rb
+++ b/db/migrate/20240705173503_create_tasks.rb
@@ -3,7 +3,7 @@ class CreateTasks < ActiveRecord::Migration[7.1]
     create_table :tasks do |t|
       t.string :title
       t.text :description
-      t.string :category
+      t.references :category, null: false, foreign_key: true
 
       t.timestamps
     end

--- a/db/migrate/20240705173956_create_categories.rb
+++ b/db/migrate/20240705173956_create_categories.rb
@@ -2,7 +2,6 @@ class CreateCategories < ActiveRecord::Migration[7.1]
   def change
     create_table :categories do |t|
       t.string :name
-      t.references :task, null: false, foreign_key: true
 
       t.timestamps
     end


### PR DESCRIPTION
## Summary
Creates an active record association between the Task and Category models

## Details
- Incorporates the .references method within the CreateTasks migration table in order to assign each task its own category_id (primary key - foreign key relationship)
- Updates the Category model to have many tasks
- Updates the Task model to belong to one category

## Testing
- [ ] Specs
- [ ] Manual
- [x] Not applicable
